### PR TITLE
add additional video fields and, schemas and enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,13 @@
 ## v0.1.7
 * __Add Schemas:__
   * `triniti:canvas:mixin:google-map-block`
+  * `triniti:ovp:tvpg-rating`
   * `triniti:ovp.kaltura:mixin:media-entry`
 * __Modify Schemas:__ _(no version changes as there is no production use yet)_
   * `triniti:ovp:mixin:video`
     * Add `credit` string field.
     * Add `caption_urls` string field.
-    * Add `tvpg_rating` string-enum field.
+    * Add `tvpg_rating` string-enum field using enum `triniti:ovp:tvpg-rating`.
     * Add `mezzanine_url` string field with format url.
     * Add `mezzanine_id` identifier (AssetId) field.
   * `triniti:dam:mixin:get-upload-urls-response`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,17 @@
 
 ## v0.1.7
 * __Add Schemas:__
+  * `triniti:canvas:mixin:google-map-block`
   * `triniti:ovp.kaltura:mixin:media-entry`
 * __Modify Schemas:__ _(no version changes as there is no production use yet)_
   * `triniti:ovp:mixin:video`
     * Add `credit` string field.
     * Add `caption_urls` string field.
-    * Add `tvpg_rating` string enum field.
-    * Add `mezzanine_url` string field.
-    * Add `mezzanine_id` identifier field.
+    * Add `tvpg_rating` string-enum field.
+    * Add `mezzanine_url` string field with format url.
+    * Add `mezzanine_id` identifier (AssetId) field.
   * `triniti:dam:mixin:get-upload-urls-response`
-    * Update "s3_presigned_urls" field type from "string" to "text"
+    * Update `s3_presigned_urls` field type from string to text to allow for the long.
 
 
 ## v0.1.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
     * Add `tvpg_rating` string enum field.
     * Add `mezzanine_url` string field.
     * Add `mezzanine_id` identifier field.
+  * `triniti:dam:mixin:get-upload-urls-response`
+    * Update "s3_presigned_urls" field type from "string" to "text"
 
 * __Add Schemas:__
   * `triniti:ovp.kaltura:mixin:media-entry`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # CHANGELOG
 
 
+## v0.1.7
+* __Modify Schemas:__ _(no version changes as there is no production use yet)_
+  * `triniti:ovp:mixin:video`
+    * Add `credit` string field.
+    * Add `caption_urls` string field.
+    * Add `tvpg_rating` string enum field.
+    * Add `mezzanine_url` string field.
+    * Add `mezzanine_id` identifier field.
+
+* __Add Schemas:__
+  * `triniti:ovp.kaltura:mixin:media-entry`
+
+
 ## v0.1.6
 * Add missing namespace `triniti:common` to `pbjc.yml` and recompile.
 

--- a/build/js/src/triniti/canvas/mixin/google-map-block/GoogleMapBlockV1Mixin.js
+++ b/build/js/src/triniti/canvas/mixin/google-map-block/GoogleMapBlockV1Mixin.js
@@ -1,0 +1,33 @@
+// @link http://schemas.triniti.io/json-schema/triniti/canvas/mixin/google-map-block/1-0-0.json#
+import Fb from '@gdbots/pbj/FieldBuilder';
+import Mixin from '@gdbots/pbj/Mixin';
+import SchemaId from '@gdbots/pbj/SchemaId';
+import T from '@gdbots/pbj/types';
+
+export default class GoogleMapBlockV1Mixin extends Mixin {
+  /**
+   * @returns {SchemaId}
+   */
+  getId() {
+    return SchemaId.fromString('pbj:triniti:canvas:mixin:google-map-block:1-0-0');
+  }
+
+  /**
+   * @returns {Field[]}
+   */
+  getFields() {
+    return [
+      Fb.create('q', T.StringType.create())
+        .build(),
+      Fb.create('center', T.GeoPointType.create())
+        .build(),
+      Fb.create('zoom', T.TinyIntType.create())
+        .max(21)
+        .build(),
+      Fb.create('maptype', T.StringType.create())
+        .pattern('^(roadmap|satellite)$')
+        .withDefault("roadmap")
+        .build(),
+    ];
+  }
+}

--- a/build/js/src/triniti/canvas/mixin/google-map-block/GoogleMapBlockV1Trait.js
+++ b/build/js/src/triniti/canvas/mixin/google-map-block/GoogleMapBlockV1Trait.js
@@ -1,0 +1,16 @@
+export default function GoogleMapBlockV1Trait(m) {
+  Object.assign(m.prototype, {
+    /**
+     * @returns {Object}
+     */
+    getUriTemplateVars() {
+      return {
+        etag: this.get('etag'),
+        q: this.get('q'),
+        center: `${this.get('center', '')}`,
+        zoom: this.get('zoom'),
+        maptype: this.get('maptype'),
+      };
+    }
+  });
+}

--- a/build/js/src/triniti/dam/mixin/get-upload-urls-response/GetUploadUrlsResponseV1Mixin.js
+++ b/build/js/src/triniti/dam/mixin/get-upload-urls-response/GetUploadUrlsResponseV1Mixin.js
@@ -31,7 +31,7 @@ export default class GetUploadUrlsResponseV1Mixin extends Mixin {
        * A map of URLs with an md5 hash of the client file name as the key
        * and the S3 presigned URL as the value.
        */
-      Fb.create('s3_presigned_urls', T.StringType.create())
+      Fb.create('s3_presigned_urls', T.TextType.create())
         .asAMap()
         .format(Format.URL)
         .build(),

--- a/build/js/src/triniti/ovp.kaltura/mixin/media-entry/MediaEntryV1Mixin.js
+++ b/build/js/src/triniti/ovp.kaltura/mixin/media-entry/MediaEntryV1Mixin.js
@@ -1,0 +1,55 @@
+// @link http://schemas.triniti.io/json-schema/triniti/ovp.kaltura/mixin/media-entry/1-0-0.json#
+import Fb from '@gdbots/pbj/FieldBuilder';
+import Format from '@gdbots/pbj/enums/Format';
+import Mixin from '@gdbots/pbj/Mixin';
+import SchemaId from '@gdbots/pbj/SchemaId';
+import T from '@gdbots/pbj/types';
+
+export default class MediaEntryV1Mixin extends Mixin {
+  /**
+   * @returns {SchemaId}
+   */
+  getId() {
+    return SchemaId.fromString('pbj:triniti:ovp.kaltura:mixin:media-entry:1-0-0');
+  }
+
+  /**
+   * @returns {Field[]}
+   */
+  getFields() {
+    return [
+      Fb.create('kaltura_entry_id', T.StringType.create())
+        .pattern('^[\\w-]+$')
+        .build(),
+      Fb.create('kaltura_partner_id', T.StringType.create())
+        .pattern('^[\\w-]+$')
+        .build(),
+      /*
+       * Updated at info from Kaltura
+       */
+      Fb.create('kaltura_updated_at', T.TimestampType.create())
+        .build(),
+      /*
+       * MP4 URL from Kaltura
+       */
+      Fb.create('kaltura_mp4_url', T.StringType.create())
+        .format(Format.URL)
+        .build(),
+      /*
+       * Metadata from Kaltura
+       */
+      Fb.create('kaltura_metadata', T.TextType.create())
+        .build(),
+      /*
+       * JSON with all Kaltura flavors
+       */
+      Fb.create('kaltura_flavors', T.TextType.create())
+        .build(),
+      /*
+       * Disable Kaltura sync on entry
+       */
+      Fb.create('kaltura_sync_enabled', T.BooleanType.create())
+        .build(),
+    ];
+  }
+}

--- a/build/js/src/triniti/ovp.kaltura/mixin/media-entry/MediaEntryV1Mixin.js
+++ b/build/js/src/triniti/ovp.kaltura/mixin/media-entry/MediaEntryV1Mixin.js
@@ -24,31 +24,28 @@ export default class MediaEntryV1Mixin extends Mixin {
       Fb.create('kaltura_partner_id', T.StringType.create())
         .pattern('^[\\w-]+$')
         .build(),
-      /*
-       * Updated at info from Kaltura
-       */
-      Fb.create('kaltura_updated_at', T.TimestampType.create())
+      Fb.create('kaltura_sync_enabled', T.BooleanType.create())
         .build(),
       /*
-       * MP4 URL from Kaltura
+       * Timestamp when the entry was last synced with Kaltura.
+       */
+      Fb.create('kaltura_synced_at', T.TimestampType.create())
+        .build(),
+      /*
+       * URL to the source mp4 (generally a high-res/mezzanine file).
        */
       Fb.create('kaltura_mp4_url', T.StringType.create())
         .format(Format.URL)
         .build(),
       /*
-       * Metadata from Kaltura
+       * An XML string containing the metadata profile(s) for the entry.
        */
       Fb.create('kaltura_metadata', T.TextType.create())
         .build(),
       /*
-       * JSON with all Kaltura flavors
+       * A JSON object with all of the Kaltura flavors for the entry.
        */
       Fb.create('kaltura_flavors', T.TextType.create())
-        .build(),
-      /*
-       * Disable Kaltura sync on entry
-       */
-      Fb.create('kaltura_sync_enabled', T.BooleanType.create())
         .build(),
     ];
   }

--- a/build/js/src/triniti/ovp/enums/TvpgRating.js
+++ b/build/js/src/triniti/ovp/enums/TvpgRating.js
@@ -1,0 +1,15 @@
+import Enum from '@gdbots/common/Enum';
+
+export default class TvpgRating extends Enum {
+}
+
+TvpgRating.configure({
+  UNKNOWN: 'unknown',
+  TV_G: 'TV-G',
+  TV_MA: 'TV-MA',
+  TV_PG: 'TV-PG',
+  TV_Y: 'TV-Y',
+  TV_Y7: 'TV-Y7',
+  TV_Y7_FV: 'TV-Y7-FV',
+  TV_14: 'TV-14',
+}, 'triniti:ovp:tvpg-rating');

--- a/build/js/src/triniti/ovp/mixin/video/VideoV1Mixin.js
+++ b/build/js/src/triniti/ovp/mixin/video/VideoV1Mixin.js
@@ -55,7 +55,7 @@ export default class VideoV1Mixin extends Mixin {
         .classProto(NodeRef)
         .build(),
       /*
-       * URL to the caption file keyed by the language code e.g. "en", "fr".
+       * URL to the caption file keyed by the language code, e.g. "en", "fr".
        */
       Fb.create('caption_urls', T.StringType.create())
         .asAMap()
@@ -65,14 +65,13 @@ export default class VideoV1Mixin extends Mixin {
         .classProto(TvpgRating)
         .build(),
       /*
-       * Mezzanine URL of video asset.
+       * URL to the mezzanine video asset.
        */
       Fb.create('mezzanine_url', T.StringType.create())
         .format(Format.URL)
         .build(),
       /*
-       * A map of asset ids with an md5 hash of the client file name as the
-       * key and the generated asset id as the value.
+       * A reference to the mezzanine asset in DAM for this video.
        */
       Fb.create('mezzanine_id', T.IdentifierType.create())
         .classProto(AssetId)

--- a/build/js/src/triniti/ovp/mixin/video/VideoV1Mixin.js
+++ b/build/js/src/triniti/ovp/mixin/video/VideoV1Mixin.js
@@ -1,9 +1,12 @@
 // @link http://schemas.triniti.io/json-schema/triniti/ovp/mixin/video/1-0-0.json#
+import AssetId from '@triniti/schemas/triniti/dam/AssetId';
 import Fb from '@gdbots/pbj/FieldBuilder';
+import Format from '@gdbots/pbj/enums/Format';
 import Mixin from '@gdbots/pbj/Mixin';
 import NodeRef from '@gdbots/schemas/gdbots/ncr/NodeRef';
 import SchemaId from '@gdbots/pbj/SchemaId';
 import T from '@gdbots/pbj/types';
+import TvpgRating from '@triniti/schemas/triniti/ovp/enums/TvpgRating';
 
 export default class VideoV1Mixin extends Mixin {
   /**
@@ -36,6 +39,12 @@ export default class VideoV1Mixin extends Mixin {
         .maxLength(5000)
         .build(),
       /*
+       * A credit is a short string used to publicly acknowledge the source/creator
+       * of the video. e.g. "Fox News", "CNN".
+       */
+      Fb.create('credit', T.StringType.create())
+        .build(),
+      /*
        * A swipe (aka banner/label/overlay) is a short string used in a visual treatment
        * on the video. e.g. "Exclusive", "NSFW", "Breaking Bad Mojo".
        */
@@ -44,6 +53,29 @@ export default class VideoV1Mixin extends Mixin {
       Fb.create('related_videos', T.IdentifierType.create())
         .asAList()
         .classProto(NodeRef)
+        .build(),
+      /*
+       * URL to the caption file keyed by the language code e.g. "en", "fr".
+       */
+      Fb.create('caption_urls', T.StringType.create())
+        .asAMap()
+        .format(Format.URL)
+        .build(),
+      Fb.create('tvpg_rating', T.StringEnumType.create())
+        .classProto(TvpgRating)
+        .build(),
+      /*
+       * Mezzanine URL of video asset.
+       */
+      Fb.create('mezzanine_url', T.StringType.create())
+        .format(Format.URL)
+        .build(),
+      /*
+       * A map of asset ids with an md5 hash of the client file name as the
+       * key and the generated asset id as the value.
+       */
+      Fb.create('mezzanine_id', T.IdentifierType.create())
+        .classProto(AssetId)
         .build(),
     ];
   }

--- a/build/php/src/Triniti/Schemas/Canvas/Mixin/GoogleMapBlock/GoogleMapBlock.php
+++ b/build/php/src/Triniti/Schemas/Canvas/Mixin/GoogleMapBlock/GoogleMapBlock.php
@@ -1,0 +1,9 @@
+<?php
+// @link http://schemas.triniti.io/json-schema/triniti/canvas/mixin/google-map-block/latest.json#
+namespace Triniti\Schemas\Canvas\Mixin\GoogleMapBlock;
+
+use Triniti\Schemas\Canvas\Mixin\Block\Block;
+
+interface GoogleMapBlock extends Block
+{
+}

--- a/build/php/src/Triniti/Schemas/Canvas/Mixin/GoogleMapBlock/GoogleMapBlockV1.php
+++ b/build/php/src/Triniti/Schemas/Canvas/Mixin/GoogleMapBlock/GoogleMapBlockV1.php
@@ -1,0 +1,7 @@
+<?php
+// @link http://schemas.triniti.io/json-schema/triniti/canvas/mixin/google-map-block/1-0-0.json#
+namespace Triniti\Schemas\Canvas\Mixin\GoogleMapBlock;
+
+interface GoogleMapBlockV1 extends GoogleMapBlock
+{
+}

--- a/build/php/src/Triniti/Schemas/Canvas/Mixin/GoogleMapBlock/GoogleMapBlockV1Mixin.php
+++ b/build/php/src/Triniti/Schemas/Canvas/Mixin/GoogleMapBlock/GoogleMapBlockV1Mixin.php
@@ -1,0 +1,39 @@
+<?php
+// @link http://schemas.triniti.io/json-schema/triniti/canvas/mixin/google-map-block/1-0-0.json#
+namespace Triniti\Schemas\Canvas\Mixin\GoogleMapBlock;
+
+use Gdbots\Pbj\AbstractMixin;
+use Gdbots\Pbj\FieldBuilder as Fb;
+use Gdbots\Pbj\SchemaId;
+use Gdbots\Pbj\Type as T;
+
+final class GoogleMapBlockV1Mixin extends AbstractMixin
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getId()
+    {
+        return SchemaId::fromString('pbj:triniti:canvas:mixin:google-map-block:1-0-0');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFields()
+    {
+        return [
+            Fb::create('q', T\StringType::create())
+                ->build(),
+            Fb::create('center', T\GeoPointType::create())
+                ->build(),
+            Fb::create('zoom', T\TinyIntType::create())
+                ->max(21)
+                ->build(),
+            Fb::create('maptype', T\StringType::create())
+                ->pattern('^(roadmap|satellite)$')
+                ->withDefault("roadmap")
+                ->build(),
+        ];
+    }
+}

--- a/build/php/src/Triniti/Schemas/Canvas/Mixin/GoogleMapBlock/GoogleMapBlockV1Trait.php
+++ b/build/php/src/Triniti/Schemas/Canvas/Mixin/GoogleMapBlock/GoogleMapBlockV1Trait.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Triniti\Schemas\Canvas\Mixin\GoogleMapBlock;
+
+use Gdbots\Pbj\Schema;
+
+/**
+ * @method static Schema schema
+ * @method mixed get($fieldName, $default = null)
+ */
+trait GoogleMapBlockV1Trait
+{
+    /**
+     * @return array
+     */
+    public function getUriTemplateVars()
+    {
+        return [
+            'etag' => $this->get('etag'),
+            'q' => $this->get('q'),
+            'center' => (string)$this->get('center'),
+            'zoom' => $this->get('zoom'),
+            'maptype' => $this->get('maptype'),
+        ];
+    }
+}

--- a/build/php/src/Triniti/Schemas/Dam/Mixin/GetUploadUrlsResponse/GetUploadUrlsResponseV1Mixin.php
+++ b/build/php/src/Triniti/Schemas/Dam/Mixin/GetUploadUrlsResponse/GetUploadUrlsResponseV1Mixin.php
@@ -37,7 +37,7 @@ final class GetUploadUrlsResponseV1Mixin extends AbstractMixin
              * A map of URLs with an md5 hash of the client file name as the key
              * and the S3 presigned URL as the value.
              */
-            Fb::create('s3_presigned_urls', T\StringType::create())
+            Fb::create('s3_presigned_urls', T\TextType::create())
                 ->asAMap()
                 ->format(Format::URL())
                 ->build(),

--- a/build/php/src/Triniti/Schemas/Ovp/Enum/TvpgRating.php
+++ b/build/php/src/Triniti/Schemas/Ovp/Enum/TvpgRating.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Triniti\Schemas\Ovp\Enum;
+
+use Gdbots\Common\Enum;
+
+/**
+ * @method static TvpgRating UNKNOWN()
+ * @method static TvpgRating TV_G()
+ * @method static TvpgRating TV_MA()
+ * @method static TvpgRating TV_PG()
+ * @method static TvpgRating TV_Y()
+ * @method static TvpgRating TV_Y7()
+ * @method static TvpgRating TV_Y7_FV()
+ * @method static TvpgRating TV_14()
+ */
+final class TvpgRating extends Enum
+{
+    const UNKNOWN = 'unknown';
+    const TV_G = 'TV-G';
+    const TV_MA = 'TV-MA';
+    const TV_PG = 'TV-PG';
+    const TV_Y = 'TV-Y';
+    const TV_Y7 = 'TV-Y7';
+    const TV_Y7_FV = 'TV-Y7-FV';
+    const TV_14 = 'TV-14';
+}

--- a/build/php/src/Triniti/Schemas/Ovp/Mixin/Video/VideoV1Mixin.php
+++ b/build/php/src/Triniti/Schemas/Ovp/Mixin/Video/VideoV1Mixin.php
@@ -61,7 +61,7 @@ final class VideoV1Mixin extends AbstractMixin
                 ->className(NodeRef::class)
                 ->build(),
             /*
-             * URL to the caption file keyed by the language code e.g. "en", "fr".
+             * URL to the caption file keyed by the language code, e.g. "en", "fr".
              */
             Fb::create('caption_urls', T\StringType::create())
                 ->asAMap()
@@ -71,14 +71,13 @@ final class VideoV1Mixin extends AbstractMixin
                 ->className(TvpgRating::class)
                 ->build(),
             /*
-             * Mezzanine URL of video asset.
+             * URL to the mezzanine video asset.
              */
             Fb::create('mezzanine_url', T\StringType::create())
                 ->format(Format::URL())
                 ->build(),
             /*
-             * A map of asset ids with an md5 hash of the client file name as the
-             * key and the generated asset id as the value.
+             * A reference to the mezzanine asset in DAM for this video.
              */
             Fb::create('mezzanine_id', T\IdentifierType::create())
                 ->className(AssetId::class)

--- a/build/php/src/Triniti/Schemas/Ovp/Mixin/Video/VideoV1Mixin.php
+++ b/build/php/src/Triniti/Schemas/Ovp/Mixin/Video/VideoV1Mixin.php
@@ -3,10 +3,13 @@
 namespace Triniti\Schemas\Ovp\Mixin\Video;
 
 use Gdbots\Pbj\AbstractMixin;
+use Gdbots\Pbj\Enum\Format;
 use Gdbots\Pbj\FieldBuilder as Fb;
 use Gdbots\Pbj\SchemaId;
 use Gdbots\Pbj\Type as T;
 use Gdbots\Schemas\Ncr\NodeRef;
+use Triniti\Schemas\Dam\AssetId;
+use Triniti\Schemas\Ovp\Enum\TvpgRating;
 
 final class VideoV1Mixin extends AbstractMixin
 {
@@ -42,6 +45,12 @@ final class VideoV1Mixin extends AbstractMixin
                 ->maxLength(5000)
                 ->build(),
             /*
+             * A credit is a short string used to publicly acknowledge the source/creator
+             * of the video. e.g. "Fox News", "CNN".
+             */
+            Fb::create('credit', T\StringType::create())
+                ->build(),
+            /*
              * A swipe (aka banner/label/overlay) is a short string used in a visual treatment
              * on the video. e.g. "Exclusive", "NSFW", "Breaking Bad Mojo".
              */
@@ -50,6 +59,29 @@ final class VideoV1Mixin extends AbstractMixin
             Fb::create('related_videos', T\IdentifierType::create())
                 ->asAList()
                 ->className(NodeRef::class)
+                ->build(),
+            /*
+             * URL to the caption file keyed by the language code e.g. "en", "fr".
+             */
+            Fb::create('caption_urls', T\StringType::create())
+                ->asAMap()
+                ->format(Format::URL())
+                ->build(),
+            Fb::create('tvpg_rating', T\StringEnumType::create())
+                ->className(TvpgRating::class)
+                ->build(),
+            /*
+             * Mezzanine URL of video asset.
+             */
+            Fb::create('mezzanine_url', T\StringType::create())
+                ->format(Format::URL())
+                ->build(),
+            /*
+             * A map of asset ids with an md5 hash of the client file name as the
+             * key and the generated asset id as the value.
+             */
+            Fb::create('mezzanine_id', T\IdentifierType::create())
+                ->className(AssetId::class)
                 ->build(),
         ];
     }

--- a/build/php/src/Triniti/Schemas/OvpKaltura/Mixin/MediaEntry/MediaEntry.php
+++ b/build/php/src/Triniti/Schemas/OvpKaltura/Mixin/MediaEntry/MediaEntry.php
@@ -1,0 +1,9 @@
+<?php
+// @link http://schemas.triniti.io/json-schema/triniti/ovp.kaltura/mixin/media-entry/latest.json#
+namespace Triniti\Schemas\OvpKaltura\Mixin\MediaEntry;
+
+use Gdbots\Pbj\Message;
+
+interface MediaEntry extends Message
+{
+}

--- a/build/php/src/Triniti/Schemas/OvpKaltura/Mixin/MediaEntry/MediaEntryV1.php
+++ b/build/php/src/Triniti/Schemas/OvpKaltura/Mixin/MediaEntry/MediaEntryV1.php
@@ -1,0 +1,7 @@
+<?php
+// @link http://schemas.triniti.io/json-schema/triniti/ovp.kaltura/mixin/media-entry/1-0-0.json#
+namespace Triniti\Schemas\OvpKaltura\Mixin\MediaEntry;
+
+interface MediaEntryV1 extends MediaEntry
+{
+}

--- a/build/php/src/Triniti/Schemas/OvpKaltura/Mixin/MediaEntry/MediaEntryV1Mixin.php
+++ b/build/php/src/Triniti/Schemas/OvpKaltura/Mixin/MediaEntry/MediaEntryV1Mixin.php
@@ -30,31 +30,28 @@ final class MediaEntryV1Mixin extends AbstractMixin
             Fb::create('kaltura_partner_id', T\StringType::create())
                 ->pattern('^[\w-]+$')
                 ->build(),
-            /*
-             * Updated at info from Kaltura
-             */
-            Fb::create('kaltura_updated_at', T\TimestampType::create())
+            Fb::create('kaltura_sync_enabled', T\BooleanType::create())
                 ->build(),
             /*
-             * MP4 URL from Kaltura
+             * Timestamp when the entry was last synced with Kaltura.
+             */
+            Fb::create('kaltura_synced_at', T\TimestampType::create())
+                ->build(),
+            /*
+             * URL to the source mp4 (generally a high-res/mezzanine file).
              */
             Fb::create('kaltura_mp4_url', T\StringType::create())
                 ->format(Format::URL())
                 ->build(),
             /*
-             * Metadata from Kaltura
+             * An XML string containing the metadata profile(s) for the entry.
              */
             Fb::create('kaltura_metadata', T\TextType::create())
                 ->build(),
             /*
-             * JSON with all Kaltura flavors
+             * A JSON object with all of the Kaltura flavors for the entry.
              */
             Fb::create('kaltura_flavors', T\TextType::create())
-                ->build(),
-            /*
-             * Disable Kaltura sync on entry
-             */
-            Fb::create('kaltura_sync_enabled', T\BooleanType::create())
                 ->build(),
         ];
     }

--- a/build/php/src/Triniti/Schemas/OvpKaltura/Mixin/MediaEntry/MediaEntryV1Mixin.php
+++ b/build/php/src/Triniti/Schemas/OvpKaltura/Mixin/MediaEntry/MediaEntryV1Mixin.php
@@ -1,0 +1,61 @@
+<?php
+// @link http://schemas.triniti.io/json-schema/triniti/ovp.kaltura/mixin/media-entry/1-0-0.json#
+namespace Triniti\Schemas\OvpKaltura\Mixin\MediaEntry;
+
+use Gdbots\Pbj\AbstractMixin;
+use Gdbots\Pbj\Enum\Format;
+use Gdbots\Pbj\FieldBuilder as Fb;
+use Gdbots\Pbj\SchemaId;
+use Gdbots\Pbj\Type as T;
+
+final class MediaEntryV1Mixin extends AbstractMixin
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getId()
+    {
+        return SchemaId::fromString('pbj:triniti:ovp.kaltura:mixin:media-entry:1-0-0');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFields()
+    {
+        return [
+            Fb::create('kaltura_entry_id', T\StringType::create())
+                ->pattern('^[\w-]+$')
+                ->build(),
+            Fb::create('kaltura_partner_id', T\StringType::create())
+                ->pattern('^[\w-]+$')
+                ->build(),
+            /*
+             * Updated at info from Kaltura
+             */
+            Fb::create('kaltura_updated_at', T\TimestampType::create())
+                ->build(),
+            /*
+             * MP4 URL from Kaltura
+             */
+            Fb::create('kaltura_mp4_url', T\StringType::create())
+                ->format(Format::URL())
+                ->build(),
+            /*
+             * Metadata from Kaltura
+             */
+            Fb::create('kaltura_metadata', T\TextType::create())
+                ->build(),
+            /*
+             * JSON with all Kaltura flavors
+             */
+            Fb::create('kaltura_flavors', T\TextType::create())
+                ->build(),
+            /*
+             * Disable Kaltura sync on entry
+             */
+            Fb::create('kaltura_sync_enabled', T\BooleanType::create())
+                ->build(),
+        ];
+    }
+}

--- a/gh-pages/json-schema/triniti/canvas/mixin/google-map-block/1-0-0.json
+++ b/gh-pages/json-schema/triniti/canvas/mixin/google-map-block/1-0-0.json
@@ -1,0 +1,88 @@
+{
+  "id": "http://schemas.triniti.io/json-schema/triniti/canvas/mixin/google-map-block/1-0-0.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "etag": {
+      "type": "string",
+      "pattern": "^[\\w\\.:-]+$",
+      "pbj": {
+        "type": "string",
+        "rule": "single"
+      }
+    },
+    "css_class": {
+      "type": "string",
+      "pattern": "^[\\w\\s-]+$",
+      "description": "In rendering environments that support HTML the css_class can be appended to the dom elements' class attribute.",
+      "pbj": {
+        "type": "string",
+        "rule": "single"
+      }
+    },
+    "q": {
+      "type": "string",
+      "minLength": 0,
+      "maxLength": 255,
+      "pbj": {
+        "type": "string",
+        "rule": "single"
+      }
+    },
+    "center": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "pattern": "^Point$"
+        },
+        "coordinates": {
+          "type": "array",
+          "items": [
+            {
+              "required": true,
+              "type": "number",
+              "minimum": -180,
+              "maximum": 180
+            },
+            {
+              "required": true,
+              "type": "number",
+              "minimum": -90,
+              "maximum": 90
+            }
+          ]
+        }
+      },
+      "required": [
+        "type",
+        "coordinates"
+      ],
+      "additionalProperties": false,
+      "pbj": {
+        "type": "geo-point",
+        "rule": "single"
+      }
+    },
+    "zoom": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 21,
+      "pbj": {
+        "type": "tiny-int",
+        "rule": "single"
+      }
+    },
+    "maptype": {
+      "type": "string",
+      "default": "roadmap",
+      "pattern": "^(roadmap|satellite)$",
+      "pbj": {
+        "type": "string",
+        "rule": "single"
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/gh-pages/json-schema/triniti/canvas/mixin/google-map-block/latest.json
+++ b/gh-pages/json-schema/triniti/canvas/mixin/google-map-block/latest.json
@@ -1,0 +1,88 @@
+{
+  "id": "http://schemas.triniti.io/json-schema/triniti/canvas/mixin/google-map-block/1-0-0.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "etag": {
+      "type": "string",
+      "pattern": "^[\\w\\.:-]+$",
+      "pbj": {
+        "type": "string",
+        "rule": "single"
+      }
+    },
+    "css_class": {
+      "type": "string",
+      "pattern": "^[\\w\\s-]+$",
+      "description": "In rendering environments that support HTML the css_class can be appended to the dom elements' class attribute.",
+      "pbj": {
+        "type": "string",
+        "rule": "single"
+      }
+    },
+    "q": {
+      "type": "string",
+      "minLength": 0,
+      "maxLength": 255,
+      "pbj": {
+        "type": "string",
+        "rule": "single"
+      }
+    },
+    "center": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "pattern": "^Point$"
+        },
+        "coordinates": {
+          "type": "array",
+          "items": [
+            {
+              "required": true,
+              "type": "number",
+              "minimum": -180,
+              "maximum": 180
+            },
+            {
+              "required": true,
+              "type": "number",
+              "minimum": -90,
+              "maximum": 90
+            }
+          ]
+        }
+      },
+      "required": [
+        "type",
+        "coordinates"
+      ],
+      "additionalProperties": false,
+      "pbj": {
+        "type": "geo-point",
+        "rule": "single"
+      }
+    },
+    "zoom": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 21,
+      "pbj": {
+        "type": "tiny-int",
+        "rule": "single"
+      }
+    },
+    "maptype": {
+      "type": "string",
+      "default": "roadmap",
+      "pattern": "^(roadmap|satellite)$",
+      "pbj": {
+        "type": "string",
+        "rule": "single"
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/gh-pages/json-schema/triniti/dam/mixin/get-upload-urls-response/1-0-0.json
+++ b/gh-pages/json-schema/triniti/dam/mixin/get-upload-urls-response/1-0-0.json
@@ -122,7 +122,7 @@
       "additionalProperties": false,
       "description": "A map of URLs with an md5 hash of the client file name as the key and the S3 presigned URL as the value.",
       "pbj": {
-        "type": "string",
+        "type": "text",
         "rule": "map",
         "format": "url"
       }

--- a/gh-pages/json-schema/triniti/dam/mixin/get-upload-urls-response/latest.json
+++ b/gh-pages/json-schema/triniti/dam/mixin/get-upload-urls-response/latest.json
@@ -122,7 +122,7 @@
       "additionalProperties": false,
       "description": "A map of URLs with an md5 hash of the client file name as the key and the S3 presigned URL as the value.",
       "pbj": {
-        "type": "string",
+        "type": "text",
         "rule": "map",
         "format": "url"
       }

--- a/gh-pages/json-schema/triniti/ovp.kaltura/mixin/media-entry/1-0-0.json
+++ b/gh-pages/json-schema/triniti/ovp.kaltura/mixin/media-entry/1-0-0.json
@@ -1,0 +1,72 @@
+{
+  "id": "http://schemas.triniti.io/json-schema/triniti/ovp.kaltura/mixin/media-entry/1-0-0.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "kaltura_entry_id": {
+      "type": "string",
+      "pattern": "^[\\w-]+$",
+      "pbj": {
+        "type": "string",
+        "rule": "single"
+      }
+    },
+    "kaltura_partner_id": {
+      "type": "string",
+      "pattern": "^[\\w-]+$",
+      "pbj": {
+        "type": "string",
+        "rule": "single"
+      }
+    },
+    "kaltura_updated_at": {
+      "type": "integer",
+      "minimum": -2147483648,
+      "maximum": 2147483647,
+      "description": "Updated at info from Kaltura",
+      "pbj": {
+        "type": "timestamp",
+        "rule": "single"
+      }
+    },
+    "kaltura_mp4_url": {
+      "type": "string",
+      "pattern": "^(https?:\\/\\/)?([\\da-z\\.-]+)\\.([a-z\\.]{2,6})([\\/\\w \\.-]*)*\\/?$",
+      "description": "MP4 URL from Kaltura",
+      "pbj": {
+        "type": "string",
+        "rule": "single",
+        "format": "url"
+      }
+    },
+    "kaltura_metadata": {
+      "type": "string",
+      "minLength": 0,
+      "maxLength": 65535,
+      "description": "Metadata from Kaltura",
+      "pbj": {
+        "type": "text",
+        "rule": "single"
+      }
+    },
+    "kaltura_flavors": {
+      "type": "string",
+      "minLength": 0,
+      "maxLength": 65535,
+      "description": "JSON with all Kaltura flavors",
+      "pbj": {
+        "type": "text",
+        "rule": "single"
+      }
+    },
+    "kaltura_sync_enabled": {
+      "type": "boolean",
+      "description": "Disable Kaltura sync on entry",
+      "pbj": {
+        "type": "boolean",
+        "rule": "single"
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/gh-pages/json-schema/triniti/ovp.kaltura/mixin/media-entry/1-0-0.json
+++ b/gh-pages/json-schema/triniti/ovp.kaltura/mixin/media-entry/1-0-0.json
@@ -19,11 +19,18 @@
         "rule": "single"
       }
     },
-    "kaltura_updated_at": {
+    "kaltura_sync_enabled": {
+      "type": "boolean",
+      "pbj": {
+        "type": "boolean",
+        "rule": "single"
+      }
+    },
+    "kaltura_synced_at": {
       "type": "integer",
       "minimum": -2147483648,
       "maximum": 2147483647,
-      "description": "Updated at info from Kaltura",
+      "description": "Timestamp when the entry was last synced with Kaltura.",
       "pbj": {
         "type": "timestamp",
         "rule": "single"
@@ -32,7 +39,7 @@
     "kaltura_mp4_url": {
       "type": "string",
       "pattern": "^(https?:\\/\\/)?([\\da-z\\.-]+)\\.([a-z\\.]{2,6})([\\/\\w \\.-]*)*\\/?$",
-      "description": "MP4 URL from Kaltura",
+      "description": "URL to the source mp4 (generally a high-res/mezzanine file).",
       "pbj": {
         "type": "string",
         "rule": "single",
@@ -43,7 +50,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 65535,
-      "description": "Metadata from Kaltura",
+      "description": "An XML string containing the metadata profile(s) for the entry.",
       "pbj": {
         "type": "text",
         "rule": "single"
@@ -53,17 +60,9 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 65535,
-      "description": "JSON with all Kaltura flavors",
+      "description": "A JSON object with all of the Kaltura flavors for the entry.",
       "pbj": {
         "type": "text",
-        "rule": "single"
-      }
-    },
-    "kaltura_sync_enabled": {
-      "type": "boolean",
-      "description": "Disable Kaltura sync on entry",
-      "pbj": {
-        "type": "boolean",
         "rule": "single"
       }
     }

--- a/gh-pages/json-schema/triniti/ovp.kaltura/mixin/media-entry/latest.json
+++ b/gh-pages/json-schema/triniti/ovp.kaltura/mixin/media-entry/latest.json
@@ -1,0 +1,72 @@
+{
+  "id": "http://schemas.triniti.io/json-schema/triniti/ovp.kaltura/mixin/media-entry/1-0-0.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "kaltura_entry_id": {
+      "type": "string",
+      "pattern": "^[\\w-]+$",
+      "pbj": {
+        "type": "string",
+        "rule": "single"
+      }
+    },
+    "kaltura_partner_id": {
+      "type": "string",
+      "pattern": "^[\\w-]+$",
+      "pbj": {
+        "type": "string",
+        "rule": "single"
+      }
+    },
+    "kaltura_updated_at": {
+      "type": "integer",
+      "minimum": -2147483648,
+      "maximum": 2147483647,
+      "description": "Updated at info from Kaltura",
+      "pbj": {
+        "type": "timestamp",
+        "rule": "single"
+      }
+    },
+    "kaltura_mp4_url": {
+      "type": "string",
+      "pattern": "^(https?:\\/\\/)?([\\da-z\\.-]+)\\.([a-z\\.]{2,6})([\\/\\w \\.-]*)*\\/?$",
+      "description": "MP4 URL from Kaltura",
+      "pbj": {
+        "type": "string",
+        "rule": "single",
+        "format": "url"
+      }
+    },
+    "kaltura_metadata": {
+      "type": "string",
+      "minLength": 0,
+      "maxLength": 65535,
+      "description": "Metadata from Kaltura",
+      "pbj": {
+        "type": "text",
+        "rule": "single"
+      }
+    },
+    "kaltura_flavors": {
+      "type": "string",
+      "minLength": 0,
+      "maxLength": 65535,
+      "description": "JSON with all Kaltura flavors",
+      "pbj": {
+        "type": "text",
+        "rule": "single"
+      }
+    },
+    "kaltura_sync_enabled": {
+      "type": "boolean",
+      "description": "Disable Kaltura sync on entry",
+      "pbj": {
+        "type": "boolean",
+        "rule": "single"
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/gh-pages/json-schema/triniti/ovp.kaltura/mixin/media-entry/latest.json
+++ b/gh-pages/json-schema/triniti/ovp.kaltura/mixin/media-entry/latest.json
@@ -19,11 +19,18 @@
         "rule": "single"
       }
     },
-    "kaltura_updated_at": {
+    "kaltura_sync_enabled": {
+      "type": "boolean",
+      "pbj": {
+        "type": "boolean",
+        "rule": "single"
+      }
+    },
+    "kaltura_synced_at": {
       "type": "integer",
       "minimum": -2147483648,
       "maximum": 2147483647,
-      "description": "Updated at info from Kaltura",
+      "description": "Timestamp when the entry was last synced with Kaltura.",
       "pbj": {
         "type": "timestamp",
         "rule": "single"
@@ -32,7 +39,7 @@
     "kaltura_mp4_url": {
       "type": "string",
       "pattern": "^(https?:\\/\\/)?([\\da-z\\.-]+)\\.([a-z\\.]{2,6})([\\/\\w \\.-]*)*\\/?$",
-      "description": "MP4 URL from Kaltura",
+      "description": "URL to the source mp4 (generally a high-res/mezzanine file).",
       "pbj": {
         "type": "string",
         "rule": "single",
@@ -43,7 +50,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 65535,
-      "description": "Metadata from Kaltura",
+      "description": "An XML string containing the metadata profile(s) for the entry.",
       "pbj": {
         "type": "text",
         "rule": "single"
@@ -53,17 +60,9 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 65535,
-      "description": "JSON with all Kaltura flavors",
+      "description": "A JSON object with all of the Kaltura flavors for the entry.",
       "pbj": {
         "type": "text",
-        "rule": "single"
-      }
-    },
-    "kaltura_sync_enabled": {
-      "type": "boolean",
-      "description": "Disable Kaltura sync on entry",
-      "pbj": {
-        "type": "boolean",
         "rule": "single"
       }
     }

--- a/gh-pages/json-schema/triniti/ovp/mixin/video/1-0-0.json
+++ b/gh-pages/json-schema/triniti/ovp/mixin/video/1-0-0.json
@@ -246,7 +246,7 @@
         }
       },
       "additionalProperties": false,
-      "description": "URL to the caption file keyed by the language code e.g. \"en\", \"fr\".",
+      "description": "URL to the caption file keyed by the language code, e.g. \"en\", \"fr\".",
       "pbj": {
         "type": "string",
         "rule": "map",
@@ -273,7 +273,7 @@
     "mezzanine_url": {
       "type": "string",
       "pattern": "^(https?:\\/\\/)?([\\da-z\\.-]+)\\.([a-z\\.]{2,6})([\\/\\w \\.-]*)*\\/?$",
-      "description": "Mezzanine URL of video asset.",
+      "description": "URL to the mezzanine video asset.",
       "pbj": {
         "type": "string",
         "rule": "single",
@@ -283,7 +283,7 @@
     "mezzanine_id": {
       "type": "string",
       "pattern": "^[\\w\\/\\.:-]+$",
-      "description": "A map of asset ids with an md5 hash of the client file name as the key and the generated asset id as the value.",
+      "description": "A reference to the mezzanine asset in DAM for this video.",
       "pbj": {
         "type": "identifier",
         "rule": "single"

--- a/gh-pages/json-schema/triniti/ovp/mixin/video/1-0-0.json
+++ b/gh-pages/json-schema/triniti/ovp/mixin/video/1-0-0.json
@@ -203,6 +203,16 @@
         "rule": "single"
       }
     },
+    "credit": {
+      "type": "string",
+      "minLength": 0,
+      "maxLength": 255,
+      "description": "A credit is a short string used to publicly acknowledge the source/creator of the video. e.g. \"Fox News\", \"CNN\".",
+      "pbj": {
+        "type": "string",
+        "rule": "single"
+      }
+    },
     "swipe": {
       "type": "string",
       "minLength": 0,
@@ -225,6 +235,58 @@
       "pbj": {
         "type": "identifier",
         "rule": "list"
+      }
+    },
+    "caption_urls": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z_]{1}[\\w\\.:-]+$": {
+          "type": "string",
+          "pattern": "^(https?:\\/\\/)?([\\da-z\\.-]+)\\.([a-z\\.]{2,6})([\\/\\w \\.-]*)*\\/?$"
+        }
+      },
+      "additionalProperties": false,
+      "description": "URL to the caption file keyed by the language code e.g. \"en\", \"fr\".",
+      "pbj": {
+        "type": "string",
+        "rule": "map",
+        "format": "url"
+      }
+    },
+    "tvpg_rating": {
+      "type": "string",
+      "enum": [
+        "unknown",
+        "TV-G",
+        "TV-MA",
+        "TV-PG",
+        "TV-Y",
+        "TV-Y7",
+        "TV-Y7-FV",
+        "TV-14"
+      ],
+      "pbj": {
+        "type": "string-enum",
+        "rule": "single"
+      }
+    },
+    "mezzanine_url": {
+      "type": "string",
+      "pattern": "^(https?:\\/\\/)?([\\da-z\\.-]+)\\.([a-z\\.]{2,6})([\\/\\w \\.-]*)*\\/?$",
+      "description": "Mezzanine URL of video asset.",
+      "pbj": {
+        "type": "string",
+        "rule": "single",
+        "format": "url"
+      }
+    },
+    "mezzanine_id": {
+      "type": "string",
+      "pattern": "^[\\w\\/\\.:-]+$",
+      "description": "A map of asset ids with an md5 hash of the client file name as the key and the generated asset id as the value.",
+      "pbj": {
+        "type": "identifier",
+        "rule": "single"
       }
     }
   },

--- a/gh-pages/json-schema/triniti/ovp/mixin/video/latest.json
+++ b/gh-pages/json-schema/triniti/ovp/mixin/video/latest.json
@@ -246,7 +246,7 @@
         }
       },
       "additionalProperties": false,
-      "description": "URL to the caption file keyed by the language code e.g. \"en\", \"fr\".",
+      "description": "URL to the caption file keyed by the language code, e.g. \"en\", \"fr\".",
       "pbj": {
         "type": "string",
         "rule": "map",
@@ -273,7 +273,7 @@
     "mezzanine_url": {
       "type": "string",
       "pattern": "^(https?:\\/\\/)?([\\da-z\\.-]+)\\.([a-z\\.]{2,6})([\\/\\w \\.-]*)*\\/?$",
-      "description": "Mezzanine URL of video asset.",
+      "description": "URL to the mezzanine video asset.",
       "pbj": {
         "type": "string",
         "rule": "single",
@@ -283,7 +283,7 @@
     "mezzanine_id": {
       "type": "string",
       "pattern": "^[\\w\\/\\.:-]+$",
-      "description": "A map of asset ids with an md5 hash of the client file name as the key and the generated asset id as the value.",
+      "description": "A reference to the mezzanine asset in DAM for this video.",
       "pbj": {
         "type": "identifier",
         "rule": "single"

--- a/gh-pages/json-schema/triniti/ovp/mixin/video/latest.json
+++ b/gh-pages/json-schema/triniti/ovp/mixin/video/latest.json
@@ -203,6 +203,16 @@
         "rule": "single"
       }
     },
+    "credit": {
+      "type": "string",
+      "minLength": 0,
+      "maxLength": 255,
+      "description": "A credit is a short string used to publicly acknowledge the source/creator of the video. e.g. \"Fox News\", \"CNN\".",
+      "pbj": {
+        "type": "string",
+        "rule": "single"
+      }
+    },
     "swipe": {
       "type": "string",
       "minLength": 0,
@@ -225,6 +235,58 @@
       "pbj": {
         "type": "identifier",
         "rule": "list"
+      }
+    },
+    "caption_urls": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z_]{1}[\\w\\.:-]+$": {
+          "type": "string",
+          "pattern": "^(https?:\\/\\/)?([\\da-z\\.-]+)\\.([a-z\\.]{2,6})([\\/\\w \\.-]*)*\\/?$"
+        }
+      },
+      "additionalProperties": false,
+      "description": "URL to the caption file keyed by the language code e.g. \"en\", \"fr\".",
+      "pbj": {
+        "type": "string",
+        "rule": "map",
+        "format": "url"
+      }
+    },
+    "tvpg_rating": {
+      "type": "string",
+      "enum": [
+        "unknown",
+        "TV-G",
+        "TV-MA",
+        "TV-PG",
+        "TV-Y",
+        "TV-Y7",
+        "TV-Y7-FV",
+        "TV-14"
+      ],
+      "pbj": {
+        "type": "string-enum",
+        "rule": "single"
+      }
+    },
+    "mezzanine_url": {
+      "type": "string",
+      "pattern": "^(https?:\\/\\/)?([\\da-z\\.-]+)\\.([a-z\\.]{2,6})([\\/\\w \\.-]*)*\\/?$",
+      "description": "Mezzanine URL of video asset.",
+      "pbj": {
+        "type": "string",
+        "rule": "single",
+        "format": "url"
+      }
+    },
+    "mezzanine_id": {
+      "type": "string",
+      "pattern": "^[\\w\\/\\.:-]+$",
+      "description": "A map of asset ids with an md5 hash of the client file name as the key and the generated asset id as the value.",
+      "pbj": {
+        "type": "identifier",
+        "rule": "single"
       }
     }
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@triniti/schemas",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@triniti/schemas",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Schemas for common Triniti apps and components.",
   "repository": {
     "type": "git",

--- a/pbjc.yml
+++ b/pbjc.yml
@@ -7,6 +7,7 @@ namespaces:
   - triniti:dam
   - triniti:news
   - triniti:ovp
+  - triniti:ovp.kaltura
 
 languages:
   php:

--- a/schemas/triniti/canvas/mixin/google-map-block/1-0-0.xml
+++ b/schemas/triniti/canvas/mixin/google-map-block/1-0-0.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<pbj-schema xmlns="http://gdbots.io/pbj/xsd"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://gdbots.io/pbj/xsd http://gdbots.io/pbj/xsd/schema.xsd">
+
+  <!--
+    @link https://developers.google.com/maps/documentation/embed/guide#optional_parameters
+  -->
+  <schema id="pbj:triniti:canvas:mixin:google-map-block:1-0-0" mixin="true" extends="triniti:canvas:mixin:block:v1">
+    <fields>
+      <field name="q" type="string"/>
+      <field name="center" type="geo-point"/>
+      <field name="zoom" type="tiny-int" max="21"/>
+      <field name="maptype" type="string" pattern="^(roadmap|satellite)$">
+        <default>roadmap</default>
+      </field>
+    </fields>
+
+    <php-options>
+      <insertion-points>
+        <imports/>
+        <methods>
+          <![CDATA[
+/**
+ * @return array
+ */
+public function getUriTemplateVars()
+{
+    return [
+        'etag' => $this->get('etag'),
+        'q' => $this->get('q'),
+        'center' => (string)$this->get('center'),
+        'zoom' => $this->get('zoom'),
+        'maptype' => $this->get('maptype'),
+    ];
+}
+          ]]>
+        </methods>
+      </insertion-points>
+    </php-options>
+
+    <js-options>
+      <insertion-points>
+        <methods>
+          <![CDATA[
+/**
+ * @returns {Object}
+ */
+getUriTemplateVars() {
+  return {
+    etag: this.get('etag'),
+    q: this.get('q'),
+    center: `${this.get('center', '')}`,
+    zoom: this.get('zoom'),
+    maptype: this.get('maptype'),
+  };
+}
+          ]]>
+        </methods>
+      </insertion-points>
+    </js-options>
+  </schema>
+</pbj-schema>

--- a/schemas/triniti/canvas/mixin/google-map-block/latest.xml
+++ b/schemas/triniti/canvas/mixin/google-map-block/latest.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<pbj-schema xmlns="http://gdbots.io/pbj/xsd"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://gdbots.io/pbj/xsd http://gdbots.io/pbj/xsd/schema.xsd">
+
+  <!--
+    @link https://developers.google.com/maps/documentation/embed/guide#optional_parameters
+  -->
+  <schema id="pbj:triniti:canvas:mixin:google-map-block:1-0-0" mixin="true" extends="triniti:canvas:mixin:block:v1">
+    <fields>
+      <field name="q" type="string"/>
+      <field name="center" type="geo-point"/>
+      <field name="zoom" type="tiny-int" max="21"/>
+      <field name="maptype" type="string" pattern="^(roadmap|satellite)$">
+        <default>roadmap</default>
+      </field>
+    </fields>
+
+    <php-options>
+      <insertion-points>
+        <imports/>
+        <methods>
+          <![CDATA[
+/**
+ * @return array
+ */
+public function getUriTemplateVars()
+{
+    return [
+        'etag' => $this->get('etag'),
+        'q' => $this->get('q'),
+        'center' => (string)$this->get('center'),
+        'zoom' => $this->get('zoom'),
+        'maptype' => $this->get('maptype'),
+    ];
+}
+          ]]>
+        </methods>
+      </insertion-points>
+    </php-options>
+
+    <js-options>
+      <insertion-points>
+        <methods>
+          <![CDATA[
+/**
+ * @returns {Object}
+ */
+getUriTemplateVars() {
+  return {
+    etag: this.get('etag'),
+    q: this.get('q'),
+    center: `${this.get('center', '')}`,
+    zoom: this.get('zoom'),
+    maptype: this.get('maptype'),
+  };
+}
+          ]]>
+        </methods>
+      </insertion-points>
+    </js-options>
+  </schema>
+</pbj-schema>

--- a/schemas/triniti/dam/mixin/get-upload-urls-response/1-0-0.xml
+++ b/schemas/triniti/dam/mixin/get-upload-urls-response/1-0-0.xml
@@ -20,7 +20,7 @@
           <class-proto>AssetId</class-proto>
         </js-options>
       </field>
-      <field name="s3_presigned_urls" type="string" format="url" rule="map">
+      <field name="s3_presigned_urls" type="text" format="url" rule="map">
         <description>
           A map of URLs with an md5 hash of the client file name as the key
           and the S3 presigned URL as the value.

--- a/schemas/triniti/dam/mixin/get-upload-urls-response/latest.xml
+++ b/schemas/triniti/dam/mixin/get-upload-urls-response/latest.xml
@@ -20,7 +20,7 @@
           <class-proto>AssetId</class-proto>
         </js-options>
       </field>
-      <field name="s3_presigned_urls" type="string" format="url" rule="map">
+      <field name="s3_presigned_urls" type="text" format="url" rule="map">
         <description>
           A map of URLs with an md5 hash of the client file name as the key
           and the S3 presigned URL as the value.

--- a/schemas/triniti/ovp.kaltura/mixin/media-entry/1-0-0.xml
+++ b/schemas/triniti/ovp.kaltura/mixin/media-entry/1-0-0.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<pbj-schema xmlns="http://gdbots.io/pbj/xsd"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://gdbots.io/pbj/xsd http://gdbots.io/pbj/xsd/schema.xsd">
+
+  <schema id="pbj:triniti:ovp.kaltura:mixin:media-entry:1-0-0" mixin="true">
+    <fields>
+      <field name="kaltura_entry_id" type="string" pattern="^[\w-]+$"/>
+      <field name="kaltura_partner_id" type="string" pattern="^[\w-]+$"/>
+      <field name="kaltura_updated_at" type="timestamp">
+        <description>
+          Updated at info from Kaltura
+        </description>
+      </field>
+      <field name="kaltura_mp4_url" type="string" format="url">
+        <description>
+          MP4 URL from Kaltura
+        </description>
+      </field>
+      <field name="kaltura_metadata" type="text">
+        <description>
+          Metadata from Kaltura
+        </description>
+      </field>
+      <field name="kaltura_flavors" type="text">
+        <description>
+          JSON with all Kaltura flavors
+        </description>
+      </field>
+      <field name="kaltura_sync_enabled" type="boolean">
+        <description>
+          Disable Kaltura sync on entry
+        </description>
+      </field>
+    </fields>
+  </schema>
+</pbj-schema>

--- a/schemas/triniti/ovp.kaltura/mixin/media-entry/1-0-0.xml
+++ b/schemas/triniti/ovp.kaltura/mixin/media-entry/1-0-0.xml
@@ -7,29 +7,23 @@
     <fields>
       <field name="kaltura_entry_id" type="string" pattern="^[\w-]+$"/>
       <field name="kaltura_partner_id" type="string" pattern="^[\w-]+$"/>
-      <field name="kaltura_updated_at" type="timestamp">
-        <description>
-          Updated at info from Kaltura
-        </description>
+      <field name="kaltura_sync_enabled" type="boolean"/>
+      <field name="kaltura_synced_at" type="timestamp">
+        <description>Timestamp when the entry was last synced with Kaltura.</description>
       </field>
       <field name="kaltura_mp4_url" type="string" format="url">
         <description>
-          MP4 URL from Kaltura
+          URL to the source mp4 (generally a high-res/mezzanine file).
         </description>
       </field>
       <field name="kaltura_metadata" type="text">
         <description>
-          Metadata from Kaltura
+          An XML string containing the metadata profile(s) for the entry.
         </description>
       </field>
       <field name="kaltura_flavors" type="text">
         <description>
-          JSON with all Kaltura flavors
-        </description>
-      </field>
-      <field name="kaltura_sync_enabled" type="boolean">
-        <description>
-          Disable Kaltura sync on entry
+          A JSON object with all of the Kaltura flavors for the entry.
         </description>
       </field>
     </fields>

--- a/schemas/triniti/ovp.kaltura/mixin/media-entry/latest.xml
+++ b/schemas/triniti/ovp.kaltura/mixin/media-entry/latest.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<pbj-schema xmlns="http://gdbots.io/pbj/xsd"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://gdbots.io/pbj/xsd http://gdbots.io/pbj/xsd/schema.xsd">
+
+  <schema id="pbj:triniti:ovp.kaltura:mixin:media-entry:1-0-0" mixin="true">
+    <fields>
+      <field name="kaltura_entry_id" type="string" pattern="^[\w-]+$"/>
+      <field name="kaltura_partner_id" type="string" pattern="^[\w-]+$"/>
+      <field name="kaltura_updated_at" type="timestamp">
+        <description>
+          Updated at info from Kaltura
+        </description>
+      </field>
+      <field name="kaltura_mp4_url" type="string" format="url">
+        <description>
+          MP4 URL from Kaltura
+        </description>
+      </field>
+      <field name="kaltura_metadata" type="text">
+        <description>
+          Metadata from Kaltura
+        </description>
+      </field>
+      <field name="kaltura_flavors" type="text">
+        <description>
+          JSON with all Kaltura flavors
+        </description>
+      </field>
+      <field name="kaltura_sync_enabled" type="boolean">
+        <description>
+          Disable Kaltura sync on entry
+        </description>
+      </field>
+    </fields>
+  </schema>
+</pbj-schema>

--- a/schemas/triniti/ovp.kaltura/mixin/media-entry/latest.xml
+++ b/schemas/triniti/ovp.kaltura/mixin/media-entry/latest.xml
@@ -7,29 +7,23 @@
     <fields>
       <field name="kaltura_entry_id" type="string" pattern="^[\w-]+$"/>
       <field name="kaltura_partner_id" type="string" pattern="^[\w-]+$"/>
-      <field name="kaltura_updated_at" type="timestamp">
-        <description>
-          Updated at info from Kaltura
-        </description>
+      <field name="kaltura_sync_enabled" type="boolean"/>
+      <field name="kaltura_synced_at" type="timestamp">
+        <description>Timestamp when the entry was last synced with Kaltura.</description>
       </field>
       <field name="kaltura_mp4_url" type="string" format="url">
         <description>
-          MP4 URL from Kaltura
+          URL to the source mp4 (generally a high-res/mezzanine file).
         </description>
       </field>
       <field name="kaltura_metadata" type="text">
         <description>
-          Metadata from Kaltura
+          An XML string containing the metadata profile(s) for the entry.
         </description>
       </field>
       <field name="kaltura_flavors" type="text">
         <description>
-          JSON with all Kaltura flavors
-        </description>
-      </field>
-      <field name="kaltura_sync_enabled" type="boolean">
-        <description>
-          Disable Kaltura sync on entry
+          A JSON object with all of the Kaltura flavors for the entry.
         </description>
       </field>
     </fields>

--- a/schemas/triniti/ovp/enums.xml
+++ b/schemas/triniti/ovp/enums.xml
@@ -15,5 +15,20 @@
       <option key="TITLE_DESC" value="title-desc"/>
       <option key="TITLE_ASC" value="title-asc"/>
     </enum>
+
+    <!--
+      @link https://en.wikipedia.org/wiki/TV_parental_guidelines_(US)
+      @link https://developers.google.com/youtube/v3/docs/videos#contentDetails.contentRating.tvpgRating
+    -->
+    <enum name="tvpg-rating" type="string">
+      <option key="UNKNOWN" value="unknown"/>
+      <option key="TV_G" value="TV-G"/>
+      <option key="TV_MA" value="TV-MA"/>
+      <option key="TV_PG" value="TV-PG"/>
+      <option key="TV_Y" value="TV-Y"/>
+      <option key="TV_Y7" value="TV-Y7"/>
+      <option key="TV_Y7_FV" value="TV-Y7-FV"/>
+      <option key="TV_14" value="TV-14"/>
+    </enum>
   </enums>
 </pbj-enums>

--- a/schemas/triniti/ovp/mixin/video/1-0-0.xml
+++ b/schemas/triniti/ovp/mixin/video/1-0-0.xml
@@ -3,9 +3,6 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://gdbots.io/pbj/xsd http://gdbots.io/pbj/xsd/schema.xsd">
 
-  <!--
-    fixme: add ratings?  mpaa,
-  -->
   <schema id="pbj:triniti:ovp:mixin:video:1-0-0" mixin="true" extends="gdbots:ncr:mixin:node:v1">
     <fields>
       <field name="duration" type="small-int">
@@ -19,6 +16,12 @@
         <description>
           A description of the video (usually a few sentences). It should typically
           not have HTML as it is used in metadata, feeds, SERP and social.
+        </description>
+      </field>
+      <field name="credit" type="string">
+        <description>
+          A credit is a short string used to publicly acknowledge the source/creator
+          of the video. e.g. "Fox News", "CNN".
         </description>
       </field>
       <field name="swipe" type="string">
@@ -35,6 +38,33 @@
         <js-options>
           <imports>import NodeRef from '@gdbots/schemas/gdbots/ncr/NodeRef';</imports>
           <class-proto>NodeRef</class-proto>
+        </js-options>
+      </field>
+      <field name="caption_urls" type="string" format="url" rule="map">
+        <description>
+          URL to the caption file keyed by the language code e.g. "en", "fr".
+        </description>
+      </field>
+      <field name="tvpg_rating" type="string-enum">
+        <enum id="triniti:ovp:tvpg-rating"/>
+      </field>
+      <field name="mezzanine_url" type="string" format="url">
+        <description>
+          Mezzanine URL of video asset.
+        </description>
+      </field>
+      <field name="mezzanine_id" type="identifier">
+        <description>
+          A map of asset ids with an md5 hash of the client file name as the
+          key and the generated asset id as the value.
+        </description>
+        <php-options>
+          <imports>use Triniti\Schemas\Dam\AssetId;</imports>
+          <class-name>AssetId::class</class-name>
+        </php-options>
+        <js-options>
+          <imports>import AssetId from '@triniti/schemas/triniti/dam/AssetId';</imports>
+          <class-proto>AssetId</class-proto>
         </js-options>
       </field>
     </fields>

--- a/schemas/triniti/ovp/mixin/video/1-0-0.xml
+++ b/schemas/triniti/ovp/mixin/video/1-0-0.xml
@@ -42,21 +42,18 @@
       </field>
       <field name="caption_urls" type="string" format="url" rule="map">
         <description>
-          URL to the caption file keyed by the language code e.g. "en", "fr".
+          URL to the caption file keyed by the language code, e.g. "en", "fr".
         </description>
       </field>
       <field name="tvpg_rating" type="string-enum">
         <enum id="triniti:ovp:tvpg-rating"/>
       </field>
       <field name="mezzanine_url" type="string" format="url">
-        <description>
-          Mezzanine URL of video asset.
-        </description>
+        <description>URL to the mezzanine video asset.</description>
       </field>
       <field name="mezzanine_id" type="identifier">
         <description>
-          A map of asset ids with an md5 hash of the client file name as the
-          key and the generated asset id as the value.
+          A reference to the mezzanine asset in DAM for this video.
         </description>
         <php-options>
           <imports>use Triniti\Schemas\Dam\AssetId;</imports>

--- a/schemas/triniti/ovp/mixin/video/latest.xml
+++ b/schemas/triniti/ovp/mixin/video/latest.xml
@@ -3,9 +3,6 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://gdbots.io/pbj/xsd http://gdbots.io/pbj/xsd/schema.xsd">
 
-  <!--
-    fixme: add ratings?  mpaa,
-  -->
   <schema id="pbj:triniti:ovp:mixin:video:1-0-0" mixin="true" extends="gdbots:ncr:mixin:node:v1">
     <fields>
       <field name="duration" type="small-int">
@@ -19,6 +16,12 @@
         <description>
           A description of the video (usually a few sentences). It should typically
           not have HTML as it is used in metadata, feeds, SERP and social.
+        </description>
+      </field>
+      <field name="credit" type="string">
+        <description>
+          A credit is a short string used to publicly acknowledge the source/creator
+          of the video. e.g. "Fox News", "CNN".
         </description>
       </field>
       <field name="swipe" type="string">
@@ -35,6 +38,33 @@
         <js-options>
           <imports>import NodeRef from '@gdbots/schemas/gdbots/ncr/NodeRef';</imports>
           <class-proto>NodeRef</class-proto>
+        </js-options>
+      </field>
+      <field name="caption_urls" type="string" format="url" rule="map">
+        <description>
+          URL to the caption file keyed by the language code e.g. "en", "fr".
+        </description>
+      </field>
+      <field name="tvpg_rating" type="string-enum">
+        <enum id="triniti:ovp:tvpg-rating"/>
+      </field>
+      <field name="mezzanine_url" type="string" format="url">
+        <description>
+          Mezzanine URL of video asset.
+        </description>
+      </field>
+      <field name="mezzanine_id" type="identifier">
+        <description>
+          A map of asset ids with an md5 hash of the client file name as the
+          key and the generated asset id as the value.
+        </description>
+        <php-options>
+          <imports>use Triniti\Schemas\Dam\AssetId;</imports>
+          <class-name>AssetId::class</class-name>
+        </php-options>
+        <js-options>
+          <imports>import AssetId from '@triniti/schemas/triniti/dam/AssetId';</imports>
+          <class-proto>AssetId</class-proto>
         </js-options>
       </field>
     </fields>

--- a/schemas/triniti/ovp/mixin/video/latest.xml
+++ b/schemas/triniti/ovp/mixin/video/latest.xml
@@ -42,21 +42,18 @@
       </field>
       <field name="caption_urls" type="string" format="url" rule="map">
         <description>
-          URL to the caption file keyed by the language code e.g. "en", "fr".
+          URL to the caption file keyed by the language code, e.g. "en", "fr".
         </description>
       </field>
       <field name="tvpg_rating" type="string-enum">
         <enum id="triniti:ovp:tvpg-rating"/>
       </field>
       <field name="mezzanine_url" type="string" format="url">
-        <description>
-          Mezzanine URL of video asset.
-        </description>
+        <description>URL to the mezzanine video asset.</description>
       </field>
       <field name="mezzanine_id" type="identifier">
         <description>
-          A map of asset ids with an md5 hash of the client file name as the
-          key and the generated asset id as the value.
+          A reference to the mezzanine asset in DAM for this video.
         </description>
         <php-options>
           <imports>use Triniti\Schemas\Dam\AssetId;</imports>


### PR DESCRIPTION
## v0.1.7
* __Modify Schemas:__ _(no version changes as there is no production use yet)_
  * `triniti:ovp:mixin:video`
    * Add `credit` string field.
    * Add `caption_urls` string field.
    * Add `tvpg_rating` string enum field.
    * Add `mezzanine_url` string field.
    * Add `mezzanine_id` identifier field.

* __Add Schemas:__
  * `triniti:ovp.kaltura:mixin:media-entry`

* Add tvpg rating enums