### PR TITLE
merge apple-news-operation into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # CHANGELOG
 
 
+## v0.13.2
+* __Modify Schemas:__ _(no version changes as there is no production use yet)_
+  * `triniti:news:mixin:apple-news-article-synced`
+    * Change `apple_news_operation` string field pattern to `^(notification|create|update|delete)$`.
+  * `triniti:notify:mixin:apple-news-notification`
+      * Change `apple_news_operation` string field pattern to `^(notification|create|update|delete)$`.
+
+
 ## v0.13.1
 * __Modify Schemas:__ _(no version changes as there is no production use yet)_
   * `triniti:news:mixin:apple-news-article-synced`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@
 * __Modify Schemas:__ _(no version changes as there is no production use yet)_
   * `triniti:news:mixin:apple-news-article-synced`
     * Change `apple_news_operation` string field pattern to `^(notification|create|update|delete)$`.
+    * Set default for `apple_news_operation` field to `notification`.
   * `triniti:notify:mixin:apple-news-notification`
-      * Change `apple_news_operation` string field pattern to `^(notification|create|update|delete)$`.
+    * Change `apple_news_operation` string field pattern to `^(notification|create|update|delete)$`.
+    * Set default for `apple_news_operation` field to `notification`.
 
 
 ## v0.13.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,28 @@
 
 ## v0.13.2
 * __Modify Schemas:__ _(no version changes as there is no production use yet)_
+  * `triniti:apollo:mixin:vote-casted`
+    * Add `s16` tiny-int field.
+    * Add `s32` tiny-int field.
+    * Add `s256` tiny-int field.
   * `triniti:news:mixin:apple-news-article-synced`
     * Change `apple_news_operation` string field pattern to `^(notification|create|update|delete)$`.
     * Set default for `apple_news_operation` field to `notification`.
+  * `triniti:news:mixin:article-stats`
+    * Add `disqus_comments` int field.
+    * Add `disqus_dislikes` int field.
+    * Add `disqus_likes` int field.
+    * Add `fb_comments` int field.
+    * Add `fb_reactions` int field.
+    * Add `fb_shares` int field.
+    * Add `ga_entrances` int field.
+    * Add `ga_entrance_rate` int field.
+    * Add `ga_pageviews` int field.
+    * Add `ga_unique_pageviews` int field.
+    * Add `ga_time_on_page` int field.
+    * Add `ga_avg_time_on_page` int field.
+    * Add `ga_exits` int field.
+    * Add `ga_exit_rate` int field.
   * `triniti:notify:mixin:apple-news-notification`
     * Change `apple_news_operation` string field pattern to `^(notification|create|update|delete)$`.
     * Set default for `apple_news_operation` field to `notification`.

--- a/build/js/src/triniti/apollo/mixin/vote-casted/VoteCastedV1Mixin.js
+++ b/build/js/src/triniti/apollo/mixin/vote-casted/VoteCastedV1Mixin.js
@@ -24,6 +24,24 @@ export default class VoteCastedV1Mixin extends Mixin {
         .build(),
       Fb.create('answer_id', T.UuidType.create())
         .build(),
+      /*
+       * "s256" means shard 256. Used to distribute read/write from storage and speed up
+       * replay/reindex processes. It can also be used to distribute workload in front end
+       * user interfaces or notifications (like isles in a grocery store).
+       * This value should NOT change once set.
+       */
+      Fb.create('s256', T.TinyIntType.create())
+        .build(),
+      /*
+       * "s32" means shard 32. See field "s256" for explanation.
+       */
+      Fb.create('s32', T.TinyIntType.create())
+        .build(),
+      /*
+       * "s16" means shard 16. See field "s256" for explanation.
+       */
+      Fb.create('s16', T.TinyIntType.create())
+        .build(),
     ];
   }
 }

--- a/build/js/src/triniti/news/mixin/apple-news-article-synced/AppleNewsArticleSyncedV1Mixin.js
+++ b/build/js/src/triniti/news/mixin/apple-news-article-synced/AppleNewsArticleSyncedV1Mixin.js
@@ -34,7 +34,8 @@ export default class AppleNewsArticleSyncedV1Mixin extends Mixin {
         .classProto(NodeRef)
         .build(),
       Fb.create('apple_news_operation', T.StringType.create())
-        .pattern('^(create|update|delete)$')
+        .pattern('^(notification|create|update|delete)$')
+        .withDefault("notification")
         .build(),
       /*
        * The unique identifier of the Apple News article.

--- a/build/js/src/triniti/news/mixin/article-stats/ArticleStatsV1Mixin.js
+++ b/build/js/src/triniti/news/mixin/article-stats/ArticleStatsV1Mixin.js
@@ -26,9 +26,35 @@ export default class ArticleStatsV1Mixin extends Mixin {
         .build(),
       Fb.create('comments', T.IntType.create())
         .build(),
+      Fb.create('views', T.IntType.create())
+        .build(),
+      Fb.create('disqus_comments', T.IntType.create())
+        .build(),
+      Fb.create('disqus_dislikes', T.IntType.create())
+        .build(),
+      Fb.create('disqus_likes', T.IntType.create())
+        .build(),
+      Fb.create('fb_comments', T.IntType.create())
+        .build(),
+      Fb.create('fb_reactions', T.IntType.create())
+        .build(),
       Fb.create('fb_shares', T.IntType.create())
         .build(),
-      Fb.create('views', T.IntType.create())
+      Fb.create('ga_entrances', T.IntType.create())
+        .build(),
+      Fb.create('ga_entrance_rate', T.IntType.create())
+        .build(),
+      Fb.create('ga_pageviews', T.IntType.create())
+        .build(),
+      Fb.create('ga_unique_pageviews', T.IntType.create())
+        .build(),
+      Fb.create('ga_time_on_page', T.IntType.create())
+        .build(),
+      Fb.create('ga_avg_time_on_page', T.IntType.create())
+        .build(),
+      Fb.create('ga_exits', T.IntType.create())
+        .build(),
+      Fb.create('ga_exit_rate', T.IntType.create())
         .build(),
     ];
   }

--- a/build/js/src/triniti/notify/mixin/apple-news-notification/AppleNewsNotificationV1Mixin.js
+++ b/build/js/src/triniti/notify/mixin/apple-news-notification/AppleNewsNotificationV1Mixin.js
@@ -18,7 +18,8 @@ export default class AppleNewsNotificationV1Mixin extends Mixin {
   getFields() {
     return [
       Fb.create('apple_news_operation', T.StringType.create())
-        .pattern('^(create|update|delete)$')
+        .pattern('^(notification|create|update|delete)$')
+        .withDefault("notification")
         .build(),
       /*
        * The unique identifier of the Apple News article.

--- a/build/php/src/Triniti/Schemas/Apollo/Mixin/VoteCasted/VoteCastedV1Mixin.php
+++ b/build/php/src/Triniti/Schemas/Apollo/Mixin/VoteCasted/VoteCastedV1Mixin.php
@@ -30,6 +30,24 @@ final class VoteCastedV1Mixin extends AbstractMixin
                 ->build(),
             Fb::create('answer_id', T\UuidType::create())
                 ->build(),
+            /*
+             * "s256" means shard 256. Used to distribute read/write from storage and speed up
+             * replay/reindex processes. It can also be used to distribute workload in front end
+             * user interfaces or notifications (like isles in a grocery store).
+             * This value should NOT change once set.
+             */
+            Fb::create('s256', T\TinyIntType::create())
+                ->build(),
+            /*
+             * "s32" means shard 32. See field "s256" for explanation.
+             */
+            Fb::create('s32', T\TinyIntType::create())
+                ->build(),
+            /*
+             * "s16" means shard 16. See field "s256" for explanation.
+             */
+            Fb::create('s16', T\TinyIntType::create())
+                ->build(),
         ];
     }
 }

--- a/build/php/src/Triniti/Schemas/News/Mixin/AppleNewsArticleSynced/AppleNewsArticleSyncedV1Mixin.php
+++ b/build/php/src/Triniti/Schemas/News/Mixin/AppleNewsArticleSynced/AppleNewsArticleSyncedV1Mixin.php
@@ -40,7 +40,8 @@ final class AppleNewsArticleSyncedV1Mixin extends AbstractMixin
                 ->className(NodeRef::class)
                 ->build(),
             Fb::create('apple_news_operation', T\StringType::create())
-                ->pattern('^(create|update|delete)$')
+                ->pattern('^(notification|create|update|delete)$')
+                ->withDefault("notification")
                 ->build(),
             /*
              * The unique identifier of the Apple News article.

--- a/build/php/src/Triniti/Schemas/News/Mixin/ArticleStats/ArticleStatsV1Mixin.php
+++ b/build/php/src/Triniti/Schemas/News/Mixin/ArticleStats/ArticleStatsV1Mixin.php
@@ -32,9 +32,35 @@ final class ArticleStatsV1Mixin extends AbstractMixin
                 ->build(),
             Fb::create('comments', T\IntType::create())
                 ->build(),
+            Fb::create('views', T\IntType::create())
+                ->build(),
+            Fb::create('disqus_comments', T\IntType::create())
+                ->build(),
+            Fb::create('disqus_dislikes', T\IntType::create())
+                ->build(),
+            Fb::create('disqus_likes', T\IntType::create())
+                ->build(),
+            Fb::create('fb_comments', T\IntType::create())
+                ->build(),
+            Fb::create('fb_reactions', T\IntType::create())
+                ->build(),
             Fb::create('fb_shares', T\IntType::create())
                 ->build(),
-            Fb::create('views', T\IntType::create())
+            Fb::create('ga_entrances', T\IntType::create())
+                ->build(),
+            Fb::create('ga_entrance_rate', T\IntType::create())
+                ->build(),
+            Fb::create('ga_pageviews', T\IntType::create())
+                ->build(),
+            Fb::create('ga_unique_pageviews', T\IntType::create())
+                ->build(),
+            Fb::create('ga_time_on_page', T\IntType::create())
+                ->build(),
+            Fb::create('ga_avg_time_on_page', T\IntType::create())
+                ->build(),
+            Fb::create('ga_exits', T\IntType::create())
+                ->build(),
+            Fb::create('ga_exit_rate', T\IntType::create())
                 ->build(),
         ];
     }

--- a/build/php/src/Triniti/Schemas/Notify/Mixin/AppleNewsNotification/AppleNewsNotificationV1Mixin.php
+++ b/build/php/src/Triniti/Schemas/Notify/Mixin/AppleNewsNotification/AppleNewsNotificationV1Mixin.php
@@ -24,7 +24,8 @@ final class AppleNewsNotificationV1Mixin extends AbstractMixin
     {
         return [
             Fb::create('apple_news_operation', T\StringType::create())
-                ->pattern('^(create|update|delete)$')
+                ->pattern('^(notification|create|update|delete)$')
+                ->withDefault("notification")
                 ->build(),
             /*
              * The unique identifier of the Apple News article.

--- a/gh-pages/json-schema/triniti/apollo/mixin/vote-casted/1-0-0.json
+++ b/gh-pages/json-schema/triniti/apollo/mixin/vote-casted/1-0-0.json
@@ -176,6 +176,39 @@
         "type": "uuid",
         "rule": "single"
       }
+    },
+    "s256": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 255,
+      "description": "\"s256\" means shard 256. Used to distribute read/write from storage and speed up replay/reindex processes. It can also be used to distribute workload in front end user interfaces or notifications (like isles in a grocery store). This value should NOT change once set.",
+      "pbj": {
+        "type": "tiny-int",
+        "rule": "single"
+      }
+    },
+    "s32": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 255,
+      "description": "\"s32\" means shard 32. See field \"s256\" for explanation.",
+      "pbj": {
+        "type": "tiny-int",
+        "rule": "single"
+      }
+    },
+    "s16": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 255,
+      "description": "\"s16\" means shard 16. See field \"s256\" for explanation.",
+      "pbj": {
+        "type": "tiny-int",
+        "rule": "single"
+      }
     }
   },
   "required": [

--- a/gh-pages/json-schema/triniti/apollo/mixin/vote-casted/latest.json
+++ b/gh-pages/json-schema/triniti/apollo/mixin/vote-casted/latest.json
@@ -176,6 +176,39 @@
         "type": "uuid",
         "rule": "single"
       }
+    },
+    "s256": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 255,
+      "description": "\"s256\" means shard 256. Used to distribute read/write from storage and speed up replay/reindex processes. It can also be used to distribute workload in front end user interfaces or notifications (like isles in a grocery store). This value should NOT change once set.",
+      "pbj": {
+        "type": "tiny-int",
+        "rule": "single"
+      }
+    },
+    "s32": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 255,
+      "description": "\"s32\" means shard 32. See field \"s256\" for explanation.",
+      "pbj": {
+        "type": "tiny-int",
+        "rule": "single"
+      }
+    },
+    "s16": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 255,
+      "description": "\"s16\" means shard 16. See field \"s256\" for explanation.",
+      "pbj": {
+        "type": "tiny-int",
+        "rule": "single"
+      }
     }
   },
   "required": [

--- a/gh-pages/json-schema/triniti/news/mixin/apple-news-article-synced/1-0-0.json
+++ b/gh-pages/json-schema/triniti/news/mixin/apple-news-article-synced/1-0-0.json
@@ -181,7 +181,8 @@
     },
     "apple_news_operation": {
       "type": "string",
-      "pattern": "^(create|update|delete)$",
+      "default": "notification",
+      "pattern": "^(notification|create|update|delete)$",
       "pbj": {
         "type": "string",
         "rule": "single"

--- a/gh-pages/json-schema/triniti/news/mixin/apple-news-article-synced/latest.json
+++ b/gh-pages/json-schema/triniti/news/mixin/apple-news-article-synced/latest.json
@@ -181,7 +181,8 @@
     },
     "apple_news_operation": {
       "type": "string",
-      "pattern": "^(create|update|delete)$",
+      "default": "notification",
+      "pattern": "^(notification|create|update|delete)$",
       "pbj": {
         "type": "string",
         "rule": "single"

--- a/gh-pages/json-schema/triniti/news/mixin/article-stats/1-0-0.json
+++ b/gh-pages/json-schema/triniti/news/mixin/article-stats/1-0-0.json
@@ -173,6 +173,66 @@
         "rule": "single"
       }
     },
+    "views": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 4294967295,
+      "pbj": {
+        "type": "int",
+        "rule": "single"
+      }
+    },
+    "disqus_comments": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 4294967295,
+      "pbj": {
+        "type": "int",
+        "rule": "single"
+      }
+    },
+    "disqus_dislikes": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 4294967295,
+      "pbj": {
+        "type": "int",
+        "rule": "single"
+      }
+    },
+    "disqus_likes": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 4294967295,
+      "pbj": {
+        "type": "int",
+        "rule": "single"
+      }
+    },
+    "fb_comments": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 4294967295,
+      "pbj": {
+        "type": "int",
+        "rule": "single"
+      }
+    },
+    "fb_reactions": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 4294967295,
+      "pbj": {
+        "type": "int",
+        "rule": "single"
+      }
+    },
     "fb_shares": {
       "type": "integer",
       "default": 0,
@@ -183,7 +243,77 @@
         "rule": "single"
       }
     },
-    "views": {
+    "ga_entrances": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 4294967295,
+      "pbj": {
+        "type": "int",
+        "rule": "single"
+      }
+    },
+    "ga_entrance_rate": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 4294967295,
+      "pbj": {
+        "type": "int",
+        "rule": "single"
+      }
+    },
+    "ga_pageviews": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 4294967295,
+      "pbj": {
+        "type": "int",
+        "rule": "single"
+      }
+    },
+    "ga_unique_pageviews": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 4294967295,
+      "pbj": {
+        "type": "int",
+        "rule": "single"
+      }
+    },
+    "ga_time_on_page": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 4294967295,
+      "pbj": {
+        "type": "int",
+        "rule": "single"
+      }
+    },
+    "ga_avg_time_on_page": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 4294967295,
+      "pbj": {
+        "type": "int",
+        "rule": "single"
+      }
+    },
+    "ga_exits": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 4294967295,
+      "pbj": {
+        "type": "int",
+        "rule": "single"
+      }
+    },
+    "ga_exit_rate": {
       "type": "integer",
       "default": 0,
       "minimum": 0,

--- a/gh-pages/json-schema/triniti/news/mixin/article-stats/latest.json
+++ b/gh-pages/json-schema/triniti/news/mixin/article-stats/latest.json
@@ -173,6 +173,66 @@
         "rule": "single"
       }
     },
+    "views": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 4294967295,
+      "pbj": {
+        "type": "int",
+        "rule": "single"
+      }
+    },
+    "disqus_comments": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 4294967295,
+      "pbj": {
+        "type": "int",
+        "rule": "single"
+      }
+    },
+    "disqus_dislikes": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 4294967295,
+      "pbj": {
+        "type": "int",
+        "rule": "single"
+      }
+    },
+    "disqus_likes": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 4294967295,
+      "pbj": {
+        "type": "int",
+        "rule": "single"
+      }
+    },
+    "fb_comments": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 4294967295,
+      "pbj": {
+        "type": "int",
+        "rule": "single"
+      }
+    },
+    "fb_reactions": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 4294967295,
+      "pbj": {
+        "type": "int",
+        "rule": "single"
+      }
+    },
     "fb_shares": {
       "type": "integer",
       "default": 0,
@@ -183,7 +243,77 @@
         "rule": "single"
       }
     },
-    "views": {
+    "ga_entrances": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 4294967295,
+      "pbj": {
+        "type": "int",
+        "rule": "single"
+      }
+    },
+    "ga_entrance_rate": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 4294967295,
+      "pbj": {
+        "type": "int",
+        "rule": "single"
+      }
+    },
+    "ga_pageviews": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 4294967295,
+      "pbj": {
+        "type": "int",
+        "rule": "single"
+      }
+    },
+    "ga_unique_pageviews": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 4294967295,
+      "pbj": {
+        "type": "int",
+        "rule": "single"
+      }
+    },
+    "ga_time_on_page": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 4294967295,
+      "pbj": {
+        "type": "int",
+        "rule": "single"
+      }
+    },
+    "ga_avg_time_on_page": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 4294967295,
+      "pbj": {
+        "type": "int",
+        "rule": "single"
+      }
+    },
+    "ga_exits": {
+      "type": "integer",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 4294967295,
+      "pbj": {
+        "type": "int",
+        "rule": "single"
+      }
+    },
+    "ga_exit_rate": {
       "type": "integer",
       "default": 0,
       "minimum": 0,

--- a/gh-pages/json-schema/triniti/notify/mixin/apple-news-notification/1-0-0.json
+++ b/gh-pages/json-schema/triniti/notify/mixin/apple-news-notification/1-0-0.json
@@ -244,7 +244,8 @@
     },
     "apple_news_operation": {
       "type": "string",
-      "pattern": "^(create|update|delete)$",
+      "default": "notification",
+      "pattern": "^(notification|create|update|delete)$",
       "pbj": {
         "type": "string",
         "rule": "single"

--- a/gh-pages/json-schema/triniti/notify/mixin/apple-news-notification/latest.json
+++ b/gh-pages/json-schema/triniti/notify/mixin/apple-news-notification/latest.json
@@ -244,7 +244,8 @@
     },
     "apple_news_operation": {
       "type": "string",
-      "pattern": "^(create|update|delete)$",
+      "default": "notification",
+      "pattern": "^(notification|create|update|delete)$",
       "pbj": {
         "type": "string",
         "rule": "single"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@triniti/schemas",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,13 +100,13 @@
       }
     },
     "@gdbots/pbj": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@gdbots/pbj/-/pbj-0.2.4.tgz",
-      "integrity": "sha512-akMfO/tgfcMPQvAEEdCe62t3IPw9jqrM2HMa5n0ngWzw6Ka0GmV5LvqtcdCrDhxe5lqdurLa/ffeXFZnLYQUXQ==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@gdbots/pbj/-/pbj-0.2.5.tgz",
+      "integrity": "sha512-OQPsLXx4rIkx4CMijcLAXzAf3hZAnBntNkgsNjBPi6m6VKfTRc/27S9E6u3YfVJCt5x0zRNhWLcVxRd6M0IZ6g==",
       "dev": true,
       "requires": {
         "base-64": "^0.1.0",
-        "bignumber.js": "^8.0.1"
+        "bignumber.js": "^8.1.1"
       }
     },
     "@gdbots/schemas": {
@@ -127,9 +127,9 @@
       "dev": true
     },
     "ajv": {
-      "version": "6.9.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.2.tgz",
-      "integrity": "sha512-4UFy0/LgDo7Oa/+wOAlj44tp9K78u38E5/359eSrqEp1Z5PdVfimCcs7SluXMP755RUQu6d2b4AvF0R1C9RZjg==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+      "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
@@ -1026,9 +1026,9 @@
       "dev": true
     },
     "bignumber.js": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-8.0.2.tgz",
-      "integrity": "sha512-EiuvFrnbv0jFixEQ9f58jo7X0qI2lNGIr/MxntmVzQc5JUweDSh8y8hbTCAomFtqwUPIOWcLXP0VEOSZTG7FFw==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-8.1.1.tgz",
+      "integrity": "sha512-QD46ppGintwPGuL1KqmwhR0O+N2cZUg8JG/VzwI2e28sM9TqHjQB10lI4QAaMHVbLzwVLLAwEglpKPViWX+5NQ==",
       "dev": true
     },
     "binary-extensions": {
@@ -1467,9 +1467,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.15.0.tgz",
-      "integrity": "sha512-xwG7SS5JLeqkiR3iOmVgtF8Y6xPdtr6AAsN6ph7Q6R/fv+3UlKYoika8SmNzmb35qdRF+RfTY35kMEdtbi+9wg==",
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.15.1.tgz",
+      "integrity": "sha512-NTcm6vQ+PTgN3UBsALw5BMhgO6i5EpIjQF/Xb5tIh3sk9QhrFafujUOczGz4J24JBlzWclSB9Vmx8d+9Z6bFCg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -2782,9 +2782,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
-          "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
         "ansi-styles": {
@@ -2808,12 +2808,12 @@
           }
         },
         "strip-ansi": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
-          "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.1.0.tgz",
+          "integrity": "sha512-TjxrkPONqO2Z8QDCpeE2j6n0M6EwxzyDgzEeGp+FbdvaJAt//ClYi6W5my+3ROlC/hZX2KACUwDfK49Ka5eDvg==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.0.0"
+            "ansi-regex": "^4.1.0"
           }
         },
         "supports-color": {
@@ -4728,29 +4728,29 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
-          "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
         "string-width": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.0.0.tgz",
-          "integrity": "sha512-rr8CUxBbvOZDUvc5lNIJ+OC1nPVpz+Siw9VBtUjB9b6jZehZLFt0JMCZzShFHIsI8cbhm0EsNIfWJMFV3cu3Ew==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
             "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.0.0"
+            "strip-ansi": "^5.1.0"
           }
         },
         "strip-ansi": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
-          "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.1.0.tgz",
+          "integrity": "sha512-TjxrkPONqO2Z8QDCpeE2j6n0M6EwxzyDgzEeGp+FbdvaJAt//ClYi6W5my+3ROlC/hZX2KACUwDfK49Ka5eDvg==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.0.0"
+            "ansi-regex": "^4.1.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@triniti/schemas",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "Schemas for common Triniti apps and components.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@gdbots/common": "^0.1.1",
-    "@gdbots/pbj": "^0.2.3",
+    "@gdbots/pbj": "^0.2.5",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",
     "babel-plugin-lodash": "^3.3.4",
@@ -39,7 +39,7 @@
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.2",
     "babel-preset-env": "^1.7.0",
     "babel-register": "^6.26.0",
-    "eslint": "^5.15.0",
+    "eslint": "^5.15.1",
     "eslint-config-airbnb": "^17.1.0",
     "eslint-import-resolver-babel-module": "^4.0.0",
     "eslint-plugin-import": "^2.15.0",

--- a/schemas/triniti/apollo/mixin/vote-casted/1-0-0.xml
+++ b/schemas/triniti/apollo/mixin/vote-casted/1-0-0.xml
@@ -20,6 +20,24 @@
         </js-options>
       </field>
       <field name="answer_id" type="uuid"/>
+      <field name="s256" type="tiny-int">
+        <description>
+          "s256" means shard 256. Used to distribute read/write from storage and speed up
+          replay/reindex processes. It can also be used to distribute workload in front end
+          user interfaces or notifications (like isles in a grocery store).
+          This value should NOT change once set.
+        </description>
+      </field>
+      <field name="s32" type="tiny-int">
+        <description>
+          "s32" means shard 32. See field "s256" for explanation.
+        </description>
+      </field>
+      <field name="s16" type="tiny-int">
+        <description>
+          "s16" means shard 16. See field "s256" for explanation.
+        </description>
+      </field>
     </fields>
   </schema>
 </pbj-schema>

--- a/schemas/triniti/apollo/mixin/vote-casted/latest.xml
+++ b/schemas/triniti/apollo/mixin/vote-casted/latest.xml
@@ -20,6 +20,24 @@
         </js-options>
       </field>
       <field name="answer_id" type="uuid"/>
+      <field name="s256" type="tiny-int">
+        <description>
+          "s256" means shard 256. Used to distribute read/write from storage and speed up
+          replay/reindex processes. It can also be used to distribute workload in front end
+          user interfaces or notifications (like isles in a grocery store).
+          This value should NOT change once set.
+        </description>
+      </field>
+      <field name="s32" type="tiny-int">
+        <description>
+          "s32" means shard 32. See field "s256" for explanation.
+        </description>
+      </field>
+      <field name="s16" type="tiny-int">
+        <description>
+          "s16" means shard 16. See field "s256" for explanation.
+        </description>
+      </field>
     </fields>
   </schema>
 </pbj-schema>

--- a/schemas/triniti/news/mixin/apple-news-article-synced/1-0-0.xml
+++ b/schemas/triniti/news/mixin/apple-news-article-synced/1-0-0.xml
@@ -34,7 +34,8 @@
       </field>
       <field name="apple_news_operation" type="string" pattern="^(notification|create|update|delete)$">
         <default>notification</default>
-      </field>      <field name="apple_news_id" type="uuid" use-type-default="false">
+      </field>
+      <field name="apple_news_id" type="uuid" use-type-default="false">
         <description>
           The unique identifier of the Apple News article.
         </description>

--- a/schemas/triniti/news/mixin/apple-news-article-synced/1-0-0.xml
+++ b/schemas/triniti/news/mixin/apple-news-article-synced/1-0-0.xml
@@ -32,8 +32,9 @@
           <class-proto>NodeRef</class-proto>
         </js-options>
       </field>
-      <field name="apple_news_operation" type="string" pattern="^(create|update|delete)$"/>
-      <field name="apple_news_id" type="uuid" use-type-default="false">
+      <field name="apple_news_operation" type="string" pattern="^(notification|create|update|delete)$">
+        <default>notification</default>
+      </field>      <field name="apple_news_id" type="uuid" use-type-default="false">
         <description>
           The unique identifier of the Apple News article.
         </description>

--- a/schemas/triniti/news/mixin/apple-news-article-synced/latest.xml
+++ b/schemas/triniti/news/mixin/apple-news-article-synced/latest.xml
@@ -34,7 +34,8 @@
       </field>
       <field name="apple_news_operation" type="string" pattern="^(notification|create|update|delete)$">
         <default>notification</default>
-      </field>      <field name="apple_news_id" type="uuid" use-type-default="false">
+      </field>
+      <field name="apple_news_id" type="uuid" use-type-default="false">
         <description>
           The unique identifier of the Apple News article.
         </description>

--- a/schemas/triniti/news/mixin/apple-news-article-synced/latest.xml
+++ b/schemas/triniti/news/mixin/apple-news-article-synced/latest.xml
@@ -32,8 +32,9 @@
           <class-proto>NodeRef</class-proto>
         </js-options>
       </field>
-      <field name="apple_news_operation" type="string" pattern="^(create|update|delete)$"/>
-      <field name="apple_news_id" type="uuid" use-type-default="false">
+      <field name="apple_news_operation" type="string" pattern="^(notification|create|update|delete)$">
+        <default>notification</default>
+      </field>      <field name="apple_news_id" type="uuid" use-type-default="false">
         <description>
           The unique identifier of the Apple News article.
         </description>

--- a/schemas/triniti/news/mixin/article-stats/1-0-0.xml
+++ b/schemas/triniti/news/mixin/article-stats/1-0-0.xml
@@ -18,8 +18,21 @@
         </js-options>
       </field>
       <field name="comments" type="int"/>
-      <field name="fb_shares" type="int"/>
       <field name="views" type="int"/>
+      <field name="disqus_comments" type="int"/>
+      <field name="disqus_dislikes" type="int"/>
+      <field name="disqus_likes" type="int"/>
+      <field name="fb_comments" type="int"/>
+      <field name="fb_reactions" type="int"/>
+      <field name="fb_shares" type="int"/>
+      <field name="ga_entrances" type="int"/>
+      <field name="ga_entrance_rate" type="int"/>
+      <field name="ga_pageviews" type="int"/>
+      <field name="ga_unique_pageviews" type="int"/>
+      <field name="ga_time_on_page" type="int"/>
+      <field name="ga_avg_time_on_page" type="int"/>
+      <field name="ga_exits" type="int"/>
+      <field name="ga_exit_rate" type="int"/>
     </fields>
 
     <php-options>

--- a/schemas/triniti/news/mixin/article-stats/latest.xml
+++ b/schemas/triniti/news/mixin/article-stats/latest.xml
@@ -18,8 +18,21 @@
         </js-options>
       </field>
       <field name="comments" type="int"/>
-      <field name="fb_shares" type="int"/>
       <field name="views" type="int"/>
+      <field name="disqus_comments" type="int"/>
+      <field name="disqus_dislikes" type="int"/>
+      <field name="disqus_likes" type="int"/>
+      <field name="fb_comments" type="int"/>
+      <field name="fb_reactions" type="int"/>
+      <field name="fb_shares" type="int"/>
+      <field name="ga_entrances" type="int"/>
+      <field name="ga_entrance_rate" type="int"/>
+      <field name="ga_pageviews" type="int"/>
+      <field name="ga_unique_pageviews" type="int"/>
+      <field name="ga_time_on_page" type="int"/>
+      <field name="ga_avg_time_on_page" type="int"/>
+      <field name="ga_exits" type="int"/>
+      <field name="ga_exit_rate" type="int"/>
     </fields>
 
     <php-options>

--- a/schemas/triniti/notify/mixin/apple-news-notification/1-0-0.xml
+++ b/schemas/triniti/notify/mixin/apple-news-notification/1-0-0.xml
@@ -6,7 +6,9 @@
   <schema id="pbj:triniti:notify:mixin:apple-news-notification:1-0-0" mixin="true"
       extends="triniti:notify:mixin:notification:v1">
     <fields>
-      <field name="apple_news_operation" type="string" pattern="^(create|update|delete)$"/>
+      <field name="apple_news_operation" type="string" pattern="^(notification|create|update|delete)$">
+        <default>notification</default>
+      </field>
       <field name="apple_news_id" type="uuid" use-type-default="false">
         <description>
           The unique identifier of the Apple News article.

--- a/schemas/triniti/notify/mixin/apple-news-notification/latest.xml
+++ b/schemas/triniti/notify/mixin/apple-news-notification/latest.xml
@@ -6,7 +6,9 @@
   <schema id="pbj:triniti:notify:mixin:apple-news-notification:1-0-0" mixin="true"
       extends="triniti:notify:mixin:notification:v1">
     <fields>
-      <field name="apple_news_operation" type="string" pattern="^(create|update|delete)$"/>
+      <field name="apple_news_operation" type="string" pattern="^(notification|create|update|delete)$">
+        <default>notification</default>
+      </field>
       <field name="apple_news_id" type="uuid" use-type-default="false">
         <description>
           The unique identifier of the Apple News article.


### PR DESCRIPTION
  * `triniti:news:mixin:apple-news-article-synced`
    * Change `apple_news_operation` string field pattern to `^(notification|create|update|delete)$`.
    * Set default for `apple_news_operation` field to `notification`.
  * `triniti:notify:mixin:apple-news-notification`
    * Change `apple_news_operation` string field pattern to `^(notification|create|update|delete)$`.
    * Set default for `apple_news_operation` field to `notification`.